### PR TITLE
update versions to conform to javax->jakarta.inject namespace change

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -17,15 +17,15 @@
 version = '0.11.0-SNAPSHOT'
 
 ext.versions = [
-    xtext: '2.26.0',
-    elk: '0.7.0',
-    guava: '[14.0,28)',
-    guice: '5.0.1',
-    gson: '2.8.6',
+    xtext: '2.26.0', // xtext: '2.32.0',
+    elk: '0.8.1',
+    guava: '32.1.2',
+    guice: '7.0.0',
+    gson: '2.10.1',
     websocket: '1.0',
     log4j: '1.2.17',
-    slf4j: '1.7.28',
+    slf4j: '1.7.36',
     junit: '4.12',
-    lsp4j: '0.12.0',
+    lsp4j: '0.12.0', // lsp4j: '0.21.1',
     jetty: '9.4.20.v20190813'
 ]

--- a/org.eclipse.sprotty.layout/src/main/java/org/eclipse/sprotty/layout/ElktSerializer.java
+++ b/org.eclipse.sprotty.layout/src/main/java/org/eclipse/sprotty/layout/ElktSerializer.java
@@ -19,8 +19,8 @@ import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 
 import org.apache.log4j.Logger;
 import org.eclipse.elk.graph.ElkNode;

--- a/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/websocket/DiagramServerEndpoint.java
+++ b/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/websocket/DiagramServerEndpoint.java
@@ -17,7 +17,7 @@ package org.eclipse.sprotty.server.websocket;
 
 import java.util.function.Consumer;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;

--- a/org.eclipse.sprotty/build.gradle
+++ b/org.eclipse.sprotty/build.gradle
@@ -18,7 +18,7 @@ ext.title = "Sprotty Diagram API"
 description = "Server API for providing sprotty diagrams"
 
 dependencies {
-	compile "javax.inject:javax.inject:1"
+	compile "jakarta.inject:jakarta.inject-api:2.0.1"
     compile "org.eclipse.xtend:org.eclipse.xtend.lib:${versions.xtext}"
     compile "log4j:log4j:${versions.log4j}"
     testCompile "junit:junit:${versions.junit}"

--- a/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/DefaultDiagramServer.java
+++ b/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/DefaultDiagramServer.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.log4j.Logger;
 import org.eclipse.sprotty.util.RejectException;


### PR DESCRIPTION
As the javax namespace is currently being phased out in newer releases, Sprotty should also jump on the train and replace old javax dependencies to work together with newer releases. Especially the latest Google Guice (com.google.inject) 7.0 release completely changes over from javax.inject to jakarta.inject dependencies, thus breaking the dependency injection of Sprotty when combined with newer versions.

In this PR I upgraded some dependencies to be more in line with the latest Eclipse 2023-09 release, especially the dependency injection framework.

I tried also updating the Java build version from 1.8 to 11, which caused unexpected build errors and Xtext and LSP4J to newer versions, which caused unexpected test errors (thrown exceptions because JUnit did not find any but expected tests in the TestLanguage classes).

This is a start to fix the injection issues with newer versions. To fully fix the problem with injecting the correct instances into extensions of the `DefaultDiagramServer` class with bindings in an extension to the `DefaultDiagramModule` class, the Xtext version probably needs to be updated as well.

What do you think of clearing up and updating the versions to release a new Sprotty server component soon? Currently in KLighD I have to resort to a workaround by re-injecting all fields of the `DefaultDiagramServer` so that it uses the correct injection framework namespace again.